### PR TITLE
Add non-interactive `yarn test` for packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,9 @@
                                 <phase>test</phase>
                                 <configuration>
                                     <arguments>test</arguments>
+                                    <environmentVariables>
+                                        <CI>true</CI>
+                                    </environmentVariables>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
Running `./mvnw package -Pprod` hangs due to `yarn test` waiting on interactive feedback. The yarn command for packaging should look like `CI=true yarn test`