### PR TITLE
In  in GroupEdit/handleSubmit function - Fixing edit group fetch + utilizing unused variable

### DIFF
--- a/app/src/GroupEdit.js
+++ b/app/src/GroupEdit.js
@@ -52,12 +52,13 @@ class GroupEdit extends Component {
 
   async handleSubmit(event) {
     event.preventDefault();
+
     const {item, csrfToken} = this.state;
 
-    await fetch('/api/group', {
+    await fetch('/api/group' + (item.id ? '/' + item.id : '') , {
       method: (item.id) ? 'PUT' : 'POST',
       headers: {
-        'X-XSRF-TOKEN': this.state.csrfToken,
+        'X-XSRF-TOKEN': csrfToken,
         'Accept': 'application/json',
         'Content-Type': 'application/json'
       },

--- a/app/src/GroupEdit.js
+++ b/app/src/GroupEdit.js
@@ -52,7 +52,6 @@ class GroupEdit extends Component {
 
   async handleSubmit(event) {
     event.preventDefault();
-
     const {item, csrfToken} = this.state;
 
     await fetch('/api/group' + (item.id ? '/' + item.id : '') , {


### PR DESCRIPTION
Love the blogs and tutorials! 

As discussed in blog article comments, the put fetch was not hitting the correct endpoint so we just changed the address it hits there. 

It looks like csrftoken was extracted from state in handleSubmit function, but was not used causing a warning in console. Referred to this variable and warning goes away. 
(it looks like in a previous PR https://github.com/oktadeveloper/okta-spring-boot-react-crud-example/pull/11 this was added, so i guess its up to you if you want to delete the variable and refer to state directly, or refer to the variable)

