### PR TITLE
NPM version property fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <java.version>17</java.version>
         <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
         <node.version>v16.18.1</node.version>
-        <npm.version>v8.19.2</npm.version>
+        <npm.version>8.19.2</npm.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
[frontend-maven-plugin ](https://github.com/eirslett/frontend-maven-plugin) cannot download the given NPM version since the URL it generates points to the non-existent archive file. thanks to [@wpernath](https://github.com/wpernath) for the [solution](https://github.com/eirslett/frontend-maven-plugin/issues/1062#issuecomment-1286214287).